### PR TITLE
refact:user 분리, 에러 관련 리팩토링(#51)

### DIFF
--- a/src/api/v1/api.py
+++ b/src/api/v1/api.py
@@ -1,10 +1,11 @@
 # api/v1/api.py
 
 from fastapi import APIRouter
-from api.v1.endpoints import user, ingredient, assistant, recipe, shopping, refrigerator
+from api.v1.endpoints import user, ingredient, assistant, recipe, shopping, refrigerator, auth
 
 api_router = APIRouter()
 
+api_router.include_router(auth.router, prefix="/auth", tags=["Auth"])
 api_router.include_router(user.router, prefix="/users", tags=["User"])
 api_router.include_router(ingredient.router, prefix="/ingredients", tags=["Ingredients"])
 api_router.include_router(assistant.router, prefix="/assistant", tags=["Assistant"])

--- a/src/api/v1/endpoints/auth.py
+++ b/src/api/v1/endpoints/auth.py
@@ -1,0 +1,72 @@
+from fastapi import Depends, APIRouter
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from core.di import get_auth_service, get_current_user, get_social_auth_service
+
+from domains.auth.schemas import LogInResponse, LogInRequest, RefreshTokenRequest, LogOutRequest
+from domains.auth.service import AuthService
+from domains.auth.social_service import SocialAuthService
+
+from domains.auth.exceptions import InvalidCredentialsException
+from util.docs import create_error_response
+
+router = APIRouter()
+
+
+@router.post(
+    "/log-in",
+    status_code=200,
+    summary="로그인 API",
+    response_model=LogInResponse,
+    responses=create_error_response(InvalidCredentialsException),
+)
+async def user_log_in(
+    request: LogInRequest,
+    req: Request,
+    auth_service: AuthService = Depends(get_auth_service),
+):
+    return await auth_service.log_in(request, req)
+
+
+@router.post(
+    "/refresh",
+    status_code=200,
+    summary="토큰 재발급 API",
+    response_model=LogInResponse,
+)
+async def refresh_token(
+    request: RefreshTokenRequest,
+    auth_service: AuthService = Depends(get_auth_service),
+):
+    return await auth_service.refresh_token(request)
+
+
+@router.post(
+    "/log-out",
+    status_code=200,
+    summary="로그아웃 API",
+)
+async def user_log_out(
+    request: LogOutRequest,
+    current_user=Depends(get_current_user),
+    auth_service: AuthService = Depends(get_auth_service),
+):
+    await auth_service.log_out(request, current_user.id)
+    return {"message": "로그아웃 되었습니다."}
+
+
+@router.get("/kakao", status_code=200, summary="카카오 로그인 URL 반환")
+async def get_kakao_url(
+    social_auth_service: SocialAuthService = Depends(get_social_auth_service),
+):
+    auth_url = await social_auth_service.get_kakao_auth_url()
+    return JSONResponse({"auth_url": auth_url})
+
+
+@router.get("/kakao/redirect", status_code=200, summary="카카오 로그인 콜백")
+async def kakao_callback(
+    code: str, state: str, social_auth_service: SocialAuthService = Depends(get_social_auth_service)
+):
+    token_response = await social_auth_service.kakao_login(code, state)
+    return token_response

--- a/src/api/v1/endpoints/user.py
+++ b/src/api/v1/endpoints/user.py
@@ -1,13 +1,11 @@
-from fastapi import APIRouter, Depends, Request
-from starlette.responses import JSONResponse
+from fastapi import APIRouter, Depends
 
-from core.di import get_user_service, get_current_user, get_social_auth_service
+from core.di import get_user_service, get_current_user
 from domains.user.exceptions import (
     DuplicateEmailException,
     DuplicateNicknameException,
     DuplicatePhoneNumException,
     InvalidCheckedPasswordException,
-    InvalidCredentialsException,
     UserNotFoundException,
     IncorrectPasswordException,
     PasswordUnchangedException,
@@ -16,17 +14,13 @@ from domains.user.exceptions import (
 from domains.user.schemas import (
     SignUpRequest,
     SignUpResponse,
-    LogInRequest,
-    LogInResponse,
     InfoResponse,
-    RefreshTokenRequest,
-    LogOutRequest,
     FindEmailRequest,
     ChangePasswordRequest,
     ResetPasswordRequest,
     ChangeNicknameRequest,
 )
-from domains.user.service import UserService, SocialAuthService
+from domains.user.service import UserService
 from util.docs import create_error_response
 
 router = APIRouter()
@@ -49,36 +43,6 @@ async def user_sign_up(request: SignUpRequest, user_service: UserService = Depen
     return SignUpResponse(email=user.email)
 
 
-@router.post(
-    "/log-in",
-    status_code=200,
-    summary="로그인 API",
-    response_model=LogInResponse,
-    responses=create_error_response(
-        InvalidCredentialsException,
-    ),
-)
-async def user_log_in(
-    request: LogInRequest,
-    req: Request,
-    user_service: UserService = Depends(get_user_service),
-):
-    return await user_service.log_in(request, req)
-
-
-@router.post(
-    "/refresh",
-    status_code=200,
-    summary="토큰 재발급 API",
-    response_model=LogInResponse,
-)
-async def refresh_token(
-    request: RefreshTokenRequest,
-    user_service: UserService = Depends(get_user_service),
-):
-    return await user_service.refresh_token(request)
-
-
 @router.get(
     "/info",
     status_code=200,
@@ -91,20 +55,6 @@ async def user_info(
     user_service: UserService = Depends(get_user_service),
 ):
     return await user_service.get_user_info(current_user.id)
-
-
-@router.post(
-    "/log-out",
-    status_code=200,
-    summary="로그아웃 API",
-)
-async def user_log_out(
-    request: LogOutRequest,
-    current_user=Depends(get_current_user),
-    user_service: UserService = Depends(get_user_service),
-):
-    await user_service.log_out(request, current_user.id)
-    return {"message": "로그아웃 되었습니다."}
 
 
 @router.post(
@@ -165,19 +115,3 @@ async def change_nickname(
     await user_service.change_nickname(request, current_user.id)
 
     return {"message": "닉네임이 변경되었습니다.", "nickname": request.nickname}
-
-
-@router.get("/kakao", status_code=200, summary="카카오 로그인 URL 반환")
-async def get_kakao_url(
-    social_auth_service: SocialAuthService = Depends(get_social_auth_service),
-):
-    auth_url = await social_auth_service.get_kakao_auth_url()
-    return JSONResponse({"auth_url": auth_url})
-
-
-@router.get("/kakao/redirect", status_code=200, summary="카카오 로그인 콜백")
-async def kakao_callback(
-    code: str, state: str, social_auth_service: SocialAuthService = Depends(get_social_auth_service)
-):
-    token_response = await social_auth_service.kakao_login(code, state)
-    return token_response

--- a/src/core/di.py
+++ b/src/core/di.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, Request
+from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from redis.asyncio import Redis
 
@@ -6,6 +6,7 @@ from core.security import get_access_token
 from core.database import get_db, get_redis
 from domains.assistant.llm_handler import LLMHandler
 from domains.assistant.service import AssistantService
+from domains.auth.service import AuthService
 
 from domains.ingredient.repository import IngredientRepository
 from domains.ingredient.service import IngredientService
@@ -16,7 +17,8 @@ from domains.refrigerator.service import RefrigeratorService
 from domains.shopping.repository import ShoppingRepository
 from domains.shopping.service import ShoppingService
 from domains.user.repository import UserRepository
-from domains.user.service import UserService, SocialAuthService
+from domains.user.service import UserService
+from domains.auth.social_service import SocialAuthService
 from domains.user.models import User
 
 
@@ -25,17 +27,21 @@ def get_user_repo(session: AsyncSession = Depends(get_db)) -> UserRepository:
     return UserRepository(session)
 
 
-def get_user_service(session: AsyncSession = Depends(get_db), redis: Redis = Depends(get_redis)) -> UserService:
-    repo = UserRepository(session)
-    return UserService(user_repo=repo, redis=redis)
+def get_user_service(user_repo: UserRepository = Depends(get_user_repo)) -> UserService:
+    return UserService(user_repo=user_repo)
+
+
+def get_auth_service(
+    user_repo: UserRepository = Depends(get_user_repo), redis: Redis = Depends(get_redis)
+) -> AuthService:
+    return AuthService(user_repo=user_repo, redis=redis)
 
 
 async def get_current_user(
-    req: Request,
     access_token: str = Depends(get_access_token),
-    user_service: UserService = Depends(get_user_service),
+    auth_service: AuthService = Depends(get_auth_service),
 ) -> User:
-    return await user_service.get_user_by_token(access_token, req)
+    return await auth_service.get_user_by_token(access_token)
 
 
 async def get_social_auth_service(

--- a/src/core/exception/errors.py
+++ b/src/core/exception/errors.py
@@ -1,0 +1,65 @@
+from enum import Enum
+
+
+class ErrorCode(str, Enum):
+    # ----------------------------------------
+    # 1. Common / Global (공통)
+    # ----------------------------------------
+    NOT_FOUND = "NOT_FOUND"  # 데이터 없음 (범용)
+    INVALID_INPUT_VALUE = "INVALID_INPUT_VALUE"  # 유효하지 않은 입력 (범용)
+    UNAUTHORIZED = "UNAUTHORIZED"  # 인증 필요 (로그인 안함)
+    INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"  # 서버 내부 에러
+
+    # ----------------------------------------
+    # 2. Auth & Token (인증/인가)
+    # ----------------------------------------
+    INVALID_CREDENTIALS = "INVALID_CREDENTIALS"  # 아이디 또는 비밀번호 틀림
+    TOKEN_EXPIRED = "TOKEN_EXPIRED"  # 토큰 만료
+    TOKEN_FORBIDDEN = "TOKEN_FORBIDDEN"  # 토큰 권한 없음 (위변조 등)
+
+    # ----------------------------------------
+    # 3. User (회원)
+    # ----------------------------------------
+    USER_NOT_FOUND = "USER_NOT_FOUND"  # 유저 찾을 수 없음
+    EMAIL_CONFLICT = "EMAIL_CONFLICT"  # 이메일 중복
+    NICKNAME_CONFLICT = "NICKNAME_CONFLICT"  # 닉네임 중복
+    PHONE_NUM_CONFLICT = "PHONE_NUM_CONFLICT"  # 전화번호 중복
+
+    PASSWORD_MISMATCH = "PASSWORD_MISMATCH"  # 비밀번호 확인 불일치 (가입/변경 시)
+    INCORRECT_PASSWORD = "INCORRECT_PASSWORD"  # 현재 비밀번호 틀림 (변경 시)
+    PASSWORD_UNCHANGED = "PASSWORD_UNCHANGED"  # 변경하려는 비번이 기존과 동일
+
+    # ----------------------------------------
+    # 4. Ingredient (식재료)
+    # ----------------------------------------
+    INGREDIENT_NOT_FOUND = "INGREDIENT_NOT_FOUND"  # 식재료 없음
+    VALUE_NOT_FOUND = "VALUE_NOT_FOUND"  # 필수 값(유통기한/보관장소) 누락
+    COMPARTMENT_NOT_FOUND = "COMPARTMENT_NOT_FOUND"  # 냉장고 칸 없음
+    INVALID_INGREDIENT = "INVALID_INGREDIENT"  # 등록 불가 식재료 포함
+
+    # ----------------------------------------
+    # 5. Recipe (레시피)
+    # ----------------------------------------
+    RECIPE_DATA_CORRUPTION = "RECIPE_DATA_CORRUPTION"  # 레시피 데이터 손상
+
+    # ----------------------------------------
+    # 6. Refrigerator (냉장고)
+    # ----------------------------------------
+    REFRIGERATOR_NOT_FOUND = "REFRIGERATOR_NOT_FOUND"  # 냉장고 없음
+
+    # ----------------------------------------
+    # 7. Shopping (장보기/아이템)
+    # ----------------------------------------
+    ITEM_NOT_FOUND = "ITEM_NOT_FOUND"  # 아이템 없음
+
+    # ----------------------------------------
+    # 8. AI Service (인공지능)
+    # ----------------------------------------
+    AI_SERVICE_ERROR = "AI_SERVICE_ERROR"  # AI 서비스 연결 오류 (503)
+    AI_CONNECTION_ERROR = "AI_CONNECTION_ERROR"  # AI 서버 연결 불가
+    AI_TIMEOUT_ERROR = "AI_TIMEOUT_ERROR"  # AI 응답 시간 초과
+    AI_NULL_RESPONSE = "AI_NULL_RESPONSE"  # AI 응답이 비어있음
+    AI_JSON_PARSE_ERROR = "AI_JSON_PARSE_ERROR"  # AI 응답 파싱 실패
+    AI_SCHEMA_ERROR = "AI_SCHEMA_ERROR"  # AI 응답 형식 불일치
+    AI_INVALID_REQUEST = "AI_INVALID_REQUEST"  # 잘못된 AI 요청
+    AI_REFUSAL_ERROR = "AI_REFUSAL_ERROR"  # AI가 답변 거부

--- a/src/core/exception/exception_handlers.py
+++ b/src/core/exception/exception_handlers.py
@@ -50,6 +50,6 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
                     error["ctx"][key] = str(value)
 
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         content=jsonable_encoder({"detail": errors, "message": "유효성 검사 실패"}),
     )

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -11,7 +11,8 @@ from cryptography.fernet import Fernet
 from jose import jwt, JWTError
 
 from core.config import settings
-from domains.user.exceptions import TokenExpiredException, UnauthorizedException
+from domains.user.exceptions import UnauthorizedException
+from domains.auth.exceptions import TokenExpiredException
 
 JWT_ALGORITHM = "HS256"
 JWT_SECRET_KEY = settings.JWT_SECRET_KEY.get_secret_value()
@@ -73,7 +74,7 @@ def decode_jwt(access_token: str) -> str:
         return user_id
 
     except JWTError:
-        return TokenExpiredException()
+        raise TokenExpiredException()
 
 
 # --- 토큰 ---

--- a/src/domains/auth/exceptions.py
+++ b/src/domains/auth/exceptions.py
@@ -1,0 +1,22 @@
+from core.exception.exceptions import BaseCustomException
+from core.exception.errors import ErrorCode
+
+
+class InvalidCredentialsException(BaseCustomException):
+    def __init__(self, detail: str = "이메일 또는 비밀번호가 잘못되었습니다"):
+        super().__init__(status_code=401, detail=detail, code=ErrorCode.INVALID_CREDENTIALS)
+
+
+class TokenExpiredException(BaseCustomException):
+    def __init__(self, detail: str = "토큰이 유효하지 않거나 만료되었습니다"):
+        super().__init__(status_code=401, detail=detail, code=ErrorCode.TOKEN_EXPIRED)
+
+
+class TokenForbiddenException(BaseCustomException):
+    def __init__(self, detail: str = "잘못된 토큰입니다."):
+        super().__init__(status_code=403, detail=detail, code=ErrorCode.TOKEN_FORBIDDEN)
+
+
+class OAuthStateMismatchException(BaseCustomException):
+    def __init__(self, detail: str = "유효하지 않은 OAuth 상태값입니다. (CSRF 공격 의심 또는 세션 만료)"):
+        super().__init__(status_code=400, detail=detail, code=ErrorCode.INVALID_INPUT_VALUE)

--- a/src/domains/auth/schemas.py
+++ b/src/domains/auth/schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel, EmailStr, constr
+
+
+class LogInRequest(BaseModel):
+    email: EmailStr
+    password: constr(min_length=8, max_length=20)
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
+
+class LogOutRequest(BaseModel):
+    refresh_token: str
+
+
+class LogInResponse(BaseModel):
+    access_token: str
+    refresh_token: str

--- a/src/domains/auth/service.py
+++ b/src/domains/auth/service.py
@@ -1,0 +1,104 @@
+from fastapi import Request
+from redis.asyncio import Redis
+
+from core import security
+from domains.auth.schemas import LogInRequest, RefreshTokenRequest, LogOutRequest, LogInResponse
+from domains.user.exceptions import (
+    UserNotFoundException,
+)
+from domains.auth.exceptions import InvalidCredentialsException, TokenExpiredException, TokenForbiddenException
+from domains.user.models import User
+from domains.user.repository import UserRepository
+
+
+class AuthService:
+    """사용자 인증관련 서비스"""
+
+    def __init__(self, user_repo: UserRepository, redis: Redis):
+        self.user_repo = user_repo
+        self.redis = redis
+
+    async def log_in(self, request: LogInRequest, req: Request) -> LogInResponse:
+        """
+        이메일/비밀번호 로그인 처리 및 토큰(Access, Refresh) 발급
+
+        Raises:
+            InvalidCredentialsException: 계정 정보 불일치 시
+        """
+        user = await self.user_repo.get_user_by_email(email=request.email)
+
+        if not user or not security.verify_password(request.password, user.password):
+            raise InvalidCredentialsException()
+
+        user_id = str(user.id)
+        access_token = security.create_jwt(user_id=user.id)
+        refresh_token = security.create_refresh_token()
+
+        await self.redis.set(
+            name=f"RT:{refresh_token}",
+            value=user_id,
+            ex=60 * 60 * 24 * 14,
+        )
+
+        return LogInResponse(
+            access_token=access_token,
+            refresh_token=refresh_token,
+        )
+
+    async def refresh_token(self, request: RefreshTokenRequest) -> LogInResponse:
+        """
+        Access Token 재발급 (RTR 적용: 사용된 Refresh 토큰은 즉시 폐기)
+
+        Raises:
+            TokenExpiredException: Refresh 토큰 만료 또는 없음
+        """
+        redis_key = f"RT:{request.refresh_token}"
+        user_id = await self.redis.get(redis_key)
+
+        if not user_id:
+            raise TokenExpiredException()
+
+        await self.redis.delete(redis_key)
+
+        new_access_token = security.create_jwt(user_id=user_id)
+        new_refresh_token = security.create_refresh_token()
+
+        await self.redis.set(
+            name=f"RT:{new_refresh_token}",
+            value=user_id,
+            ex=60 * 60 * 24 * 14,
+        )
+
+        return LogInResponse(
+            access_token=new_access_token,
+            refresh_token=new_refresh_token,
+        )
+
+    async def log_out(self, request: LogOutRequest, user_id: str) -> None:
+        redis_key = f"RT:{request.refresh_token}"
+
+        stored_user_id = await self.redis.get(redis_key)
+
+        if not stored_user_id:
+            raise TokenExpiredException()
+
+        if isinstance(stored_user_id, bytes):
+            stored_user_id = stored_user_id.decode("utf-8")
+
+        if stored_user_id != str(user_id):
+            raise TokenForbiddenException()
+
+        await self.redis.delete(redis_key)
+
+    async def get_user_by_token(self, access_token: str) -> User:
+        try:
+            user_id: str = security.decode_jwt(access_token=access_token)
+        except Exception:
+            raise TokenForbiddenException()
+
+        user: User | None = await self.user_repo.get_user_by_id(user_id)
+
+        if not user:
+            raise UserNotFoundException()
+
+        return user

--- a/src/domains/auth/social_service.py
+++ b/src/domains/auth/social_service.py
@@ -1,0 +1,118 @@
+import secrets
+
+import httpx
+from redis.asyncio import Redis
+
+from core import security
+from core.config import settings
+from domains.auth.schemas import LogInResponse
+from domains.auth.exceptions import InvalidCredentialsException, OAuthStateMismatchException
+from domains.user.models import User
+from domains.user.repository import UserRepository
+
+
+class SocialAuthService:
+    def __init__(self, user_repo: UserRepository, redis: Redis):
+        self.user_repo = user_repo
+        self.redis = redis
+
+    async def get_kakao_auth_url(self) -> str:
+        state = secrets.token_urlsafe(32)
+        await self.redis.set(f"OAUTH_STATE:{state}", "valid", ex=300)
+
+        return (
+            f"https://kauth.kakao.com/oauth/authorize?"
+            f"client_id={settings.KAKAO_REST_API_KEY}&"
+            f"redirect_uri={settings.KAKAO_REDIRECT_URI}&"
+            f"response_type=code&"
+            f"state={state}"
+        )
+
+    async def kakao_login(self, code: str, state: str) -> LogInResponse:
+        redis_key = f"OAUTH_STATE:{state}"
+        saved_state = await self.redis.get(redis_key)
+
+        if not saved_state:
+            raise OAuthStateMismatchException(detail="유효하지 않은 접근입니다. (State 불일치)")
+
+        await self.redis.delete(redis_key)
+
+        kakao_token = await self._get_kakao_token(code)
+
+        kakao_user_info = await self._get_kakao_user_info(kakao_token)
+
+        social_id = str(kakao_user_info["id"])
+
+        user = await self.user_repo.get_user_by_social_id(provider="kakao", social_id=social_id)
+
+        if not user:
+            kakao_account = kakao_user_info.get("kakao_account", {})
+            profile = kakao_account.get("profile", {})
+
+            nickname = f"k_{social_id}"
+            email = kakao_account.get("email")
+
+            new_user = User(
+                email=email,
+                nickname=nickname,
+                password=None,
+                name=profile.get("nickname", "Unknown"),
+                provider="kakao",
+                social_id=social_id,
+                phone=None,
+                phone_hash=None,
+            )
+            user = await self.user_repo.save_user(new_user)
+
+        return await self._issue_tokens(user)
+
+    async def _get_kakao_token(self, code: str) -> str:
+        url = "https://kauth.kakao.com/oauth/token"
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        data = {
+            "grant_type": "authorization_code",
+            "client_id": settings.KAKAO_REST_API_KEY,
+            "redirect_uri": settings.KAKAO_REDIRECT_URI,
+            "code": code,
+            "client_secret": settings.KAKAO_CLIENT_SECRET.get_secret_value(),
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, headers=headers, data=data)
+
+            if response.status_code != 200:
+                raise InvalidCredentialsException(detail="카카오 토큰 발급 실패")
+
+            return response.json().get("access_token")
+
+    async def _get_kakao_user_info(self, access_token: str) -> dict:
+        url = "https://kapi.kakao.com/v2/user/me"
+
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=headers)
+
+            if response.status_code != 200:
+                raise InvalidCredentialsException(detail="카카오 유저 정보 조회 실패")
+
+            return response.json()
+
+    async def _issue_tokens(self, user: User) -> LogInResponse:
+        user_id = str(user.id)
+        access_token = security.create_jwt(user_id=user_id)
+        refresh_token = security.create_refresh_token()
+
+        await self.redis.set(
+            name=f"RT:{refresh_token}",
+            value=user_id,
+            ex=60 * 60 * 24 * 14,
+        )
+
+        return LogInResponse(
+            access_token=access_token,
+            refresh_token=refresh_token,
+        )

--- a/src/domains/recipe/schemas.py
+++ b/src/domains/recipe/schemas.py
@@ -1,3 +1,4 @@
+from pydantic import ConfigDict
 from datetime import datetime
 
 from domains.assistant.schemas import DetailRecipeResponse
@@ -11,5 +12,4 @@ class SavedRecipeResponse(DetailRecipeResponse):
     id: int
     created_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/src/domains/user/exceptions.py
+++ b/src/domains/user/exceptions.py
@@ -31,21 +31,6 @@ class UserNotFoundException(BaseCustomException):
         super().__init__(status_code=404, detail=detail, code="USER_NOT_FOUND")
 
 
-class TokenExpiredException(BaseCustomException):
-    def __init__(self, detail: str = "토큰이 유효하지 않거나 만료되었습니다"):
-        super().__init__(status_code=401, detail=detail, code="TOKEN_EXPIRED")
-
-
-class InvalidCredentialsException(BaseCustomException):
-    def __init__(self, detail: str = "이메일 또는 비밀번호가 잘못되었습니다"):
-        super().__init__(status_code=401, detail=detail, code="INVALID_CREDENTIALS")
-
-
-class TokenForbiddenException(BaseCustomException):
-    def __init__(self, detail: str = "해당 토큰에 대한 권한이 없습니다"):
-        super().__init__(status_code=403, detail=detail, code="TOKEN_FORBIDDEN")
-
-
 class IncorrectPasswordException(BaseCustomException):
     def __init__(self, detail: str = "현재 비밀번호가 잘못되었습니다"):
         super().__init__(status_code=401, detail=detail, code="INCORRECT_PASSWORD")

--- a/src/domains/user/schemas.py
+++ b/src/domains/user/schemas.py
@@ -20,19 +20,6 @@ class SignUpResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class LogInRequest(BaseModel):
-    email: EmailStr
-    password: constr(min_length=8, max_length=20)
-
-
-class RefreshTokenRequest(BaseModel):
-    refresh_token: str
-
-
-class LogOutRequest(BaseModel):
-    refresh_token: str
-
-
 class FindEmailRequest(BaseModel):
     name: str
     birth: date
@@ -56,11 +43,6 @@ class ResetPasswordRequest(BaseModel):
 
 class ChangeNicknameRequest(BaseModel):
     nickname: constr(min_length=2, max_length=20)
-
-
-class LogInResponse(BaseModel):
-    access_token: str
-    refresh_token: str
 
 
 class InfoResponse(BaseModel):

--- a/src/domains/user/service.py
+++ b/src/domains/user/service.py
@@ -1,20 +1,11 @@
-from fastapi import Request
-from redis.asyncio import Redis
-import httpx
-import secrets
-
 from core import security
-from core.config import settings
 
 from domains.user.exceptions import (
     DuplicateEmailException,
     DuplicateNicknameException,
     InvalidCheckedPasswordException,
     DuplicatePhoneNumException,
-    InvalidCredentialsException,
     UserNotFoundException,
-    TokenExpiredException,
-    TokenForbiddenException,
     PasswordUnchangedException,
     PasswordMismatchException,
     IncorrectPasswordException,
@@ -22,11 +13,7 @@ from domains.user.exceptions import (
 from domains.user.repository import UserRepository
 from domains.user.schemas import (
     SignUpRequest,
-    LogInRequest,
-    LogInResponse,
     InfoResponse,
-    RefreshTokenRequest,
-    LogOutRequest,
     FindEmailRequest,
     FindEmailResponse,
     ChangePasswordRequest,
@@ -37,17 +24,8 @@ from domains.user.models import User
 
 
 class UserService:
-    def __init__(self, user_repo: UserRepository, redis: Redis):
+    def __init__(self, user_repo: UserRepository):
         self.user_repo = user_repo
-        self.redis = redis
-
-    async def get_user_by_token(self, access_token: str, req: Request) -> User:
-        user_id: str = security.decode_jwt(access_token=access_token)
-        user: User | None = await self.user_repo.get_user_by_id(user_id)
-
-        if not user:
-            raise UserNotFoundException()
-        return user
 
     async def sign_up(self, request: SignUpRequest):
         try:
@@ -89,34 +67,6 @@ class UserService:
         except Exception as e:
             raise e
 
-    async def log_in(self, request: LogInRequest, req: Request):
-        try:
-            user = await self.user_repo.get_user_by_email(email=request.email)
-
-            if not user or not security.verify_password(request.password, user.password):
-                raise InvalidCredentialsException()
-
-            user_id = str(user.id)
-
-            access_token = security.create_jwt(user_id=user.id)
-            refresh_token = security.create_refresh_token()
-            await self.redis.set(
-                name=f"RT:{refresh_token}",
-                value=user_id,
-                ex=60 * 60 * 24 * 14,  # 14일 뒤 자동 삭제
-            )
-
-            return LogInResponse(
-                access_token=access_token,
-                refresh_token=refresh_token,
-            )
-
-        except InvalidCredentialsException:
-            raise
-
-        except Exception as e:
-            raise e
-
     async def get_user_info(self, user_id: str) -> InfoResponse:
         user = await self.user_repo.get_user_by_id(user_id)
 
@@ -124,35 +74,6 @@ class UserService:
             raise UserNotFoundException()
 
         return InfoResponse(email=user.email, nickname=user.nickname)
-
-    async def refresh_token(self, request: RefreshTokenRequest) -> LogInResponse:
-        redis_key = f"RT:{request.refresh_token}"
-        user_id = await self.redis.get(redis_key)
-
-        if not user_id:
-            raise TokenExpiredException()
-
-        new_access_token = security.create_jwt(user_id=user_id)
-
-        return LogInResponse(
-            access_token=new_access_token,
-            refresh_token=request.refresh_token,
-        )
-
-    async def log_out(self, request: LogOutRequest, user_id: str) -> None:
-        redis_key = f"RT:{request.refresh_token}"
-
-        stored_user_id = await self.redis.get(redis_key)
-
-        if not stored_user_id:
-            raise TokenExpiredException()
-
-        if stored_user_id != str(user_id):
-            raise TokenForbiddenException()
-
-        await self.redis.delete(redis_key)
-
-        return None
 
     async def find_email(self, request: FindEmailRequest) -> FindEmailResponse:
         phone_hash = security.make_phone_hash(request.phone_num)
@@ -214,111 +135,3 @@ class UserService:
 
         user.nickname = request.nickname
         await self.user_repo.update_user(user)
-
-
-class SocialAuthService:
-    def __init__(self, user_repo: UserRepository, redis: Redis):
-        self.user_repo = user_repo
-        self.redis = redis
-
-    async def get_kakao_auth_url(self) -> str:
-        state = secrets.token_urlsafe(32)
-        await self.redis.set(f"OAUTH_STATE:{state}", "valid", ex=300)
-
-        return (
-            f"https://kauth.kakao.com/oauth/authorize?"
-            f"client_id={settings.KAKAO_REST_API_KEY}&"
-            f"redirect_uri={settings.KAKAO_REDIRECT_URI}&"
-            f"response_type=code&"
-            f"state={state}"
-        )
-
-    async def kakao_login(self, code: str, state: str) -> LogInResponse:
-        # 0. State 검증
-        redis_key = f"OAUTH_STATE:{state}"
-        saved_state = await self.redis.get(redis_key)
-
-        if not saved_state:
-            raise InvalidCredentialsException(detail="유효하지 않은 접근입니다. (State 불일치)")
-
-        await self.redis.delete(redis_key)
-
-        kakao_token = await self._get_kakao_token(code)
-
-        kakao_user_info = await self._get_kakao_user_info(kakao_token)
-
-        social_id = str(kakao_user_info["id"])
-
-        user = await self.user_repo.get_user_by_social_id(provider="kakao", social_id=social_id)
-
-        if not user:
-            kakao_account = kakao_user_info.get("kakao_account", {})
-            profile = kakao_account.get("profile", {})
-
-            nickname = f"k_{social_id}"
-            email = kakao_account.get("email")
-
-            new_user = User(
-                email=email,
-                nickname=nickname,
-                password=None,
-                name=profile.get("nickname", "Unknown"),
-                provider="kakao",
-                social_id=social_id,
-                phone=None,
-                phone_hash=None,
-            )
-            user = await self.user_repo.save_user(new_user)
-
-        return await self._issue_tokens(user)
-
-    async def _get_kakao_token(self, code: str) -> str:
-        url = "https://kauth.kakao.com/oauth/token"
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
-        data = {
-            "grant_type": "authorization_code",
-            "client_id": settings.KAKAO_REST_API_KEY,
-            "redirect_uri": settings.KAKAO_REDIRECT_URI,
-            "code": code,
-            "client_secret": settings.KAKAO_CLIENT_SECRET.get_secret_value(),
-        }
-
-        async with httpx.AsyncClient() as client:
-            response = await client.post(url, headers=headers, data=data)
-
-            if response.status_code != 200:
-                raise InvalidCredentialsException(detail="카카오 토큰 발급 실패")
-
-            return response.json().get("access_token")
-
-    async def _get_kakao_user_info(self, access_token: str) -> dict:
-        url = "https://kapi.kakao.com/v2/user/me"
-
-        headers = {
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-        }
-
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, headers=headers)
-
-            if response.status_code != 200:
-                raise InvalidCredentialsException(detail="카카오 유저 정보 조회 실패")
-
-            return response.json()
-
-    async def _issue_tokens(self, user: User) -> LogInResponse:
-        user_id = str(user.id)
-        access_token = security.create_jwt(user_id=user_id)
-        refresh_token = security.create_refresh_token()
-
-        await self.redis.set(
-            name=f"RT:{refresh_token}",
-            value=user_id,
-            ex=60 * 60 * 24 * 14,
-        )
-
-        return LogInResponse(
-            access_token=access_token,
-            refresh_token=refresh_token,
-        )

--- a/tests/domains/auth/test_auth_api.py
+++ b/tests/domains/auth/test_auth_api.py
@@ -1,0 +1,167 @@
+from unittest.mock import AsyncMock
+from main import app
+
+import pytest
+from core import security
+from core.di import get_social_auth_service
+
+PASSWORD = "password123!"
+
+
+@pytest.mark.asyncio
+async def test_log_in_flow(client):
+    """[API] 회원가입 후 로그인 성공 테스트"""
+    # 1. 가입 (User API 사용)
+    login_email = "login_flow@test.com"
+    await client.post(
+        "/api/v1/users/sign-up",
+        json={
+            "email": login_email,
+            "password": PASSWORD,
+            "checked_password": PASSWORD,
+            "nickname": "login_flow",
+            "name": "flow",
+        },
+    )
+
+    # 2. 로그인 (Auth API 사용)
+    response = await client.post("/api/v1/auth/log-in", json={"email": login_email, "password": PASSWORD})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_success(client, mock_redis):
+    """[API] 리프레시 토큰으로 액세스 토큰 재발급 성공"""
+    email = "refresh_success@test.com"
+    await client.post(
+        "/api/v1/users/sign-up",
+        json={
+            "email": email,
+            "password": PASSWORD,
+            "checked_password": PASSWORD,
+            "nickname": "refresh_user",
+            "name": "refresh",
+        },
+    )
+
+    login_res = await client.post("/api/v1/auth/log-in", json={"email": email, "password": PASSWORD})
+    tokens = login_res.json()
+    refresh_token = tokens["refresh_token"]
+
+    mock_redis.get.return_value = "some-user-id"
+
+    # 3. 토큰 재발급 요청
+    refresh_res = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_token})
+
+    assert refresh_res.status_code == 200
+    new_data = refresh_res.json()
+    assert "access_token" in new_data
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_fail_invalid(client, mock_redis):
+    """[API] 유효하지 않은 리프레시 토큰으로 요청 시 실패"""
+    mock_redis.get.return_value = None
+
+    response = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": "invalid_or_expired_token_string"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_logout_flow(client, mock_redis):
+    """[API] 로그아웃 시나리오 (로그인 -> 헤더 포함 로그아웃 -> 재발급 실패 확인)"""
+    email = "logout_test@test.com"
+    await client.post(
+        "/api/v1/users/sign-up",
+        json={
+            "email": email,
+            "password": PASSWORD,
+            "checked_password": PASSWORD,
+            "nickname": "logout_user",
+            "name": "logout",
+        },
+    )
+
+    login_res = await client.post("/api/v1/auth/log-in", json={"email": email, "password": PASSWORD})
+    tokens = login_res.json()
+    access_token = tokens["access_token"]
+    refresh_token = tokens["refresh_token"]
+
+    user_id = security.decode_jwt(access_token)
+    mock_redis.get.return_value = user_id
+
+    # 3. 로그아웃 요청
+    logout_res = await client.post(
+        "/api/v1/auth/log-out",
+        json={"refresh_token": refresh_token},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert logout_res.status_code == 200
+
+    mock_redis.get.return_value = None
+    retry_refresh_res = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_token})
+
+    assert retry_refresh_res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_kakao_url(client):
+    """[API] 카카오 로그인 URL 반환 테스트 (모킹)"""
+    # 1. 의존성 모킹 (SocialAuthService)
+    mock_social_auth_service = AsyncMock()
+    mock_auth_url = (
+        "https://kauth.kakao.com/oauth/authorize?client_id=dummy_client_id&redirect_uri=dummy_uri&response_type=code"
+    )
+    mock_social_auth_service.get_kakao_auth_url.return_value = mock_auth_url
+
+    # FastAPI dependency_overrides를 통해 주입될 서비스 교체
+    app.dependency_overrides[get_social_auth_service] = lambda: mock_social_auth_service
+
+    # 2. API 호출
+    response = await client.get("/api/v1/auth/kakao")
+
+    # 3. 검증
+    assert response.status_code == 200
+    assert response.json() == {"auth_url": mock_auth_url}
+    mock_social_auth_service.get_kakao_auth_url.assert_called_once()
+
+    # 4. 의존성 원상복구 (다른 테스트에 영향 주지 않도록)
+    app.dependency_overrides.pop(get_social_auth_service, None)
+
+
+@pytest.mark.asyncio
+async def test_kakao_callback_success(client):
+    """[API] 카카오 로그인 콜백 성공 테스트 (모킹)"""
+    # 1. 의존성 모킹
+    mock_social_auth_service = AsyncMock()
+    mock_token_response = {
+        "access_token": "mock_access_token",
+        "refresh_token": "mock_refresh_token",
+        "token_type": "bearer",
+    }
+    # 콜백 시 토큰을 정상적으로 반환한다고 설정
+    mock_social_auth_service.kakao_login.return_value = mock_token_response
+
+    app.dependency_overrides[get_social_auth_service] = lambda: mock_social_auth_service
+
+    # 2. API 호출 (카카오에서 리다이렉트되어 들어오는 상황 가정)
+    response = await client.get("/api/v1/auth/kakao/redirect?code=dummy_auth_code&state=dummy_state")
+
+    # 3. 검증
+    assert response.status_code == 200
+    assert response.json() == mock_token_response
+
+    # 서비스의 kakao_login 메서드가 정확한 파라미터와 함께 호출되었는지 확인
+    mock_social_auth_service.kakao_login.assert_called_once_with("dummy_auth_code", "dummy_state")
+
+    # 4. 의존성 원상복구
+    app.dependency_overrides.pop(get_social_auth_service, None)

--- a/tests/domains/auth/test_auth_service.py
+++ b/tests/domains/auth/test_auth_service.py
@@ -1,0 +1,95 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from domains.auth.service import AuthService
+from domains.auth.schemas import LogInRequest, RefreshTokenRequest, LogOutRequest
+from domains.auth.exceptions import InvalidCredentialsException
+from domains.user.models import User
+
+
+# --- Fixtures ---
+@pytest.fixture
+def mock_user_repo():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_redis():
+    return AsyncMock()
+
+
+@pytest.fixture
+def auth_service(mock_user_repo, mock_redis):
+    return AuthService(user_repo=mock_user_repo, redis=mock_redis)
+
+
+@pytest.fixture
+def mock_user():
+    user = User(email="test@example.com", password="hashed_password", nickname="tester", name="홍길동")
+    user.id = "user_id_123"
+    return user
+
+
+# --- Tests ---
+@pytest.mark.asyncio
+async def test_log_in_success(auth_service, mock_user_repo, mock_redis, mock_user):
+    """[Auth Service] 로그인 성공 및 토큰 발급"""
+    mock_user_repo.get_user_by_email.return_value = mock_user
+    request = LogInRequest(email="test@example.com", password="password123")
+
+    # security.verify_password를 모킹해서 무조건 True를 반환하도록 설정
+    with patch("domains.auth.service.security.verify_password", return_value=True):
+        with patch("domains.auth.service.security.create_jwt", return_value="mock_access_token"):
+            with patch("domains.auth.service.security.create_refresh_token", return_value="mock_refresh_token"):
+                response = await auth_service.log_in(request, req=AsyncMock())
+
+                assert response.access_token == "mock_access_token"
+                assert response.refresh_token == "mock_refresh_token"
+                mock_redis.set.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_log_in_fail_invalid_credentials(auth_service, mock_user_repo):
+    """[Auth Service] 로그인 실패 (비밀번호 불일치)"""
+    mock_user_repo.get_user_by_email.return_value = AsyncMock()  # 유저는 존재함
+    request = LogInRequest(email="test@example.com", password="wrong_password")
+
+    with patch("domains.auth.service.security.verify_password", return_value=False):
+        with pytest.raises(InvalidCredentialsException):
+            await auth_service.log_in(request, req=AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_success(auth_service, mock_redis):
+    """[Auth Service] 리프레시 토큰 재발급 성공"""
+    mock_redis.get.return_value = b"user_id_123"
+    request = RefreshTokenRequest(refresh_token="old_refresh_token")
+
+    with patch("domains.auth.service.security.create_jwt", return_value="new_access_token"):
+        with patch("domains.auth.service.security.create_refresh_token", return_value="new_refresh_token"):
+            response = await auth_service.refresh_token(request)
+
+            assert response.access_token == "new_access_token"
+            mock_redis.delete.assert_called_once_with("RT:old_refresh_token")
+            mock_redis.set.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_log_out_success(auth_service, mock_redis):
+    """[Auth Service] 로그아웃 성공 (Redis에서 토큰 삭제)"""
+    mock_redis.get.return_value = b"user_id_123"
+    request = LogOutRequest(refresh_token="valid_refresh_token")
+
+    await auth_service.log_out(request, user_id="user_id_123")
+    mock_redis.delete.assert_called_once_with("RT:valid_refresh_token")
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_token_success(auth_service, mock_user_repo, mock_user):
+    """[Auth Service] 토큰으로 유저 정보 가져오기"""
+    mock_user_repo.get_user_by_id.return_value = mock_user
+
+    with patch("domains.auth.service.security.decode_jwt", return_value="user_id_123"):
+        user = await auth_service.get_user_by_token("mock_access_token")
+
+        assert user.email == mock_user.email

--- a/tests/domains/user/test_user_api.py
+++ b/tests/domains/user/test_user_api.py
@@ -1,5 +1,4 @@
 import pytest
-from core import security
 
 # 테스트 데이터 상수
 EMAIL = "api_test@example.com"
@@ -19,20 +18,18 @@ async def test_sign_up_success(client):
             "checked_password": PASSWORD,
             "nickname": NICKNAME,
             "name": "홍길동",
-            "birth": "1990-01-01",  # [수정] YYYY-MM-DD 형식
+            "birth": "1990-01-01",
             "phone_num": PHONE,
         },
     )
 
     assert response.status_code == 201
-    data = response.json()
-    assert data["email"] == EMAIL
+    assert response.json()["email"] == EMAIL
 
 
 @pytest.mark.asyncio
 async def test_sign_up_duplicate_email(client):
     """[API] 이메일 중복 체크"""
-    # 1. 먼저 가입
     await client.post(
         "/api/v1/users/sign-up",
         json={
@@ -44,7 +41,6 @@ async def test_sign_up_duplicate_email(client):
         },
     )
 
-    # 2. 같은 이메일로 재가입 시도
     response = await client.post(
         "/api/v1/users/sign-up",
         json={
@@ -61,141 +57,24 @@ async def test_sign_up_duplicate_email(client):
 
 
 @pytest.mark.asyncio
-async def test_log_in_flow(client):
-    """[API] 회원가입 후 로그인 성공 테스트"""
-    # 1. 가입
-    login_email = "login_flow@test.com"
-    await client.post(
-        "/api/v1/users/sign-up",
-        json={
-            "email": login_email,
-            "password": PASSWORD,
-            "checked_password": PASSWORD,
-            "nickname": "login_flow",
-            "name": "flow",
-        },
-    )
-
-    # 2. 로그인
-    response = await client.post("/api/v1/users/log-in", json={"email": login_email, "password": PASSWORD})
-
-    assert response.status_code == 200
-    data = response.json()
-    assert "access_token" in data
-    assert "refresh_token" in data
-
-
-@pytest.mark.asyncio
 async def test_get_user_info(authorized_client):
     """[API] 내 정보 조회 (authorized_client 사용)"""
     response = await authorized_client.get("/api/v1/users/info")
 
     assert response.status_code == 200
     data = response.json()
+    # authorized_client 설정에 따라 검증값 조정 필요
     assert data["email"] == "test@example.com"
     assert data["nickname"] == "테스트유저"
-
-
-# --- [리프레시 토큰 및 로그아웃] ---
-
-
-@pytest.mark.asyncio
-async def test_refresh_token_success(client, mock_redis):
-    """[API] 리프레시 토큰으로 액세스 토큰 재발급 성공"""
-    # 1. 가입
-    email = "refresh_success@test.com"
-    await client.post(
-        "/api/v1/users/sign-up",
-        json={
-            "email": email,
-            "password": PASSWORD,
-            "checked_password": PASSWORD,
-            "nickname": "refresh_user",
-            "name": "refresh",
-        },
-    )
-
-    # 2. 로그인
-    login_res = await client.post("/api/v1/users/log-in", json={"email": email, "password": PASSWORD})
-    tokens = login_res.json()
-    refresh_token = tokens["refresh_token"]
-
-    # [핵심] Redis에 토큰이 존재한다고 설정
-    mock_redis.get.return_value = "some-user-id"
-
-    # 3. 토큰 재발급 요청
-    refresh_res = await client.post("/api/v1/users/refresh", json={"refresh_token": refresh_token})
-
-    assert refresh_res.status_code == 200
-    new_data = refresh_res.json()
-    assert "access_token" in new_data
-
-
-@pytest.mark.asyncio
-async def test_refresh_token_fail_invalid(client, mock_redis):
-    """[API] 유효하지 않은 리프레시 토큰으로 요청 시 실패"""
-    mock_redis.get.return_value = None
-
-    response = await client.post(
-        "/api/v1/users/refresh",
-        json={"refresh_token": "invalid_or_expired_token_string"},
-    )
-
-    assert response.status_code == 401
-
-
-@pytest.mark.asyncio
-async def test_logout_flow(client, mock_redis):
-    """[API] 로그아웃 시나리오 (로그인 -> 헤더 포함 로그아웃 -> 재발급 실패 확인)"""
-    # 1. 가입
-    email = "logout_test@test.com"
-    await client.post(
-        "/api/v1/users/sign-up",
-        json={
-            "email": email,
-            "password": PASSWORD,
-            "checked_password": PASSWORD,
-            "nickname": "logout_user",
-            "name": "logout",
-        },
-    )
-
-    # 2. 로그인
-    login_res = await client.post("/api/v1/users/log-in", json={"email": email, "password": PASSWORD})
-    tokens = login_res.json()
-    access_token = tokens["access_token"]
-    refresh_token = tokens["refresh_token"]
-
-    # 3. 로그아웃 요청 (헤더 포함 + Redis Mock 설정)
-    user_id = security.decode_jwt(access_token)
-    mock_redis.get.return_value = user_id
-
-    logout_res = await client.post(
-        "/api/v1/users/log-out",
-        json={"refresh_token": refresh_token},
-        headers={"Authorization": f"Bearer {access_token}"},
-    )
-
-    assert logout_res.status_code == 200
-
-    # 4. 검증: 로그아웃된 토큰으로 재발급 시도 -> 실패
-    mock_redis.get.return_value = None
-    retry_refresh_res = await client.post("/api/v1/users/refresh", json={"refresh_token": refresh_token})
-
-    assert retry_refresh_res.status_code == 401
-
-
-# --- [추가된 API 테스트 (수정됨)] ---
 
 
 @pytest.mark.asyncio
 async def test_find_email_success(client):
     """[API] 이메일 찾기 성공"""
-    # 1. 가입
     email = "find@test.com"
     name = "김찾기"
-    birth = "1999-01-01"  # [수정] YYYY-MM-DD
-    phone = "01011112222"  # 하이픈 없이 11자리 (스키마 length 제한 준수)
+    birth = "1999-01-01"
+    phone = "01011112222"
 
     await client.post(
         "/api/v1/users/sign-up",
@@ -210,12 +89,11 @@ async def test_find_email_success(client):
         },
     )
 
-    # 2. 이메일 찾기 요청
     response = await client.post(
         "/api/v1/users/find-email",
         json={
             "name": name,
-            "birth": birth,  # [수정] "1999-01-01" 전송
+            "birth": birth,
             "phone_num": phone,
         },
     )
@@ -227,12 +105,11 @@ async def test_find_email_success(client):
 @pytest.mark.asyncio
 async def test_find_email_fail_not_found(client):
     """[API] 정보 불일치로 이메일 찾기 실패"""
-    # [수정] birth 형식을 맞춰줘야 422(Validation Error)가 아니라 404(Not Found)가 뜹니다.
     response = await client.post(
         "/api/v1/users/find-email",
         json={
             "name": "없는사람",
-            "birth": "2000-01-01",  # [수정]
+            "birth": "2000-01-01",
             "phone_num": "01000000000",
         },
     )
@@ -246,7 +123,6 @@ async def test_change_password_success(client):
     old_pw = "old_pass_123"
     new_pw = "new_pass_123"
 
-    # 1. 가입
     await client.post(
         "/api/v1/users/sign-up",
         json={
@@ -258,15 +134,13 @@ async def test_change_password_success(client):
         },
     )
 
-    # 2. 로그인 (토큰 획득)
-    login_res = await client.post("/api/v1/users/log-in", json={"email": email, "password": old_pw})
+    # Auth API를 통해 로그인
+    login_res = await client.post("/api/v1/auth/log-in", json={"email": email, "password": old_pw})
     access_token = login_res.json()["access_token"]
 
-    # 3. 비밀번호 변경 요청
     change_res = await client.patch(
         "/api/v1/users/change-pw",
         json={
-            # [수정] old_password -> current_password (스키마 일치)
             "current_password": old_pw,
             "new_password": new_pw,
             "checked_new_password": new_pw,
@@ -274,18 +148,12 @@ async def test_change_password_success(client):
         headers={"Authorization": f"Bearer {access_token}"},
     )
 
-    # 디버깅용 로그 (혹시 또 에러나면 확인용)
-    if change_res.status_code == 422:
-        print(change_res.json())
-
     assert change_res.status_code == 200
 
-    # 4. 검증: 예전 비밀번호로 로그인 실패
-    fail_login = await client.post("/api/v1/users/log-in", json={"email": email, "password": old_pw})
+    fail_login = await client.post("/api/v1/auth/log-in", json={"email": email, "password": old_pw})
     assert fail_login.status_code == 401
 
-    # 5. 검증: 새 비밀번호로 로그인 성공
-    success_login = await client.post("/api/v1/users/log-in", json={"email": email, "password": new_pw})
+    success_login = await client.post("/api/v1/auth/log-in", json={"email": email, "password": new_pw})
     assert success_login.status_code == 200
 
 
@@ -296,10 +164,9 @@ async def test_reset_password_success(client):
     old_pw = "old_12345"
     new_pw = "reset_12345"
     name = "초기화"
-    birth = "2000-01-01"  # [수정] YYYY-MM-DD
+    birth = "2000-01-01"
     phone = "01099998888"
 
-    # 1. 가입
     await client.post(
         "/api/v1/users/sign-up",
         json={
@@ -313,13 +180,12 @@ async def test_reset_password_success(client):
         },
     )
 
-    # 2. 비밀번호 재설정 요청
     reset_res = await client.post(
         "/api/v1/users/reset-pw",
         json={
             "email": email,
             "name": name,
-            "birth": birth,  # [수정] YYYY-MM-DD
+            "birth": birth,
             "phone_num": phone,
             "new_password": new_pw,
             "checked_new_password": new_pw,
@@ -327,8 +193,7 @@ async def test_reset_password_success(client):
     )
     assert reset_res.status_code == 200
 
-    # 3. 새 비밀번호로 로그인 성공 확인
-    login_res = await client.post("/api/v1/users/log-in", json={"email": email, "password": new_pw})
+    login_res = await client.post("/api/v1/auth/log-in", json={"email": email, "password": new_pw})
     assert login_res.status_code == 200
 
 
@@ -336,7 +201,6 @@ async def test_reset_password_success(client):
 async def test_change_nickname_flow(client):
     """[API] 닉네임 변경 및 중복 체크"""
     email = "nick@test.com"
-    # 1. 가입
     await client.post(
         "/api/v1/users/sign-up",
         json={
@@ -348,11 +212,9 @@ async def test_change_nickname_flow(client):
         },
     )
 
-    # 로그인해서 토큰 받기
-    login_res = await client.post("/api/v1/users/log-in", json={"email": email, "password": PASSWORD})
+    login_res = await client.post("/api/v1/auth/log-in", json={"email": email, "password": PASSWORD})
     access_token = login_res.json()["access_token"]
 
-    # 2. 닉네임 변경 요청
     new_nick = "new_nick"
     res = await client.patch(
         "/api/v1/users/nickname", json={"nickname": new_nick}, headers={"Authorization": f"Bearer {access_token}"}
@@ -360,6 +222,5 @@ async def test_change_nickname_flow(client):
     assert res.status_code == 200
     assert res.json()["nickname"] == new_nick
 
-    # 3. 변경 확인 (내 정보 조회)
     info_res = await client.get("/api/v1/users/info", headers={"Authorization": f"Bearer {access_token}"})
     assert info_res.json()["nickname"] == new_nick

--- a/tests/domains/user/test_user_service.py
+++ b/tests/domains/user/test_user_service.py
@@ -1,317 +1,112 @@
 import pytest
-from datetime import date
 from unittest.mock import AsyncMock, patch
+
 from domains.user.service import UserService
-from domains.user.schemas import (
-    SignUpRequest,
-    LogInRequest,
-    RefreshTokenRequest,
-    LogOutRequest,
-    ChangeNicknameRequest,
-    ResetPasswordRequest,
-    ChangePasswordRequest,
-    FindEmailRequest,
-)
-from domains.user.exceptions import (
-    DuplicateEmailException,
-    InvalidCheckedPasswordException,
-    InvalidCredentialsException,
-    TokenExpiredException,
-    TokenForbiddenException,
-    DuplicateNicknameException,
-    UserNotFoundException,
-    PasswordUnchangedException,
-    IncorrectPasswordException,
-)
+from domains.user.schemas import SignUpRequest, FindEmailRequest, ChangePasswordRequest, ChangeNicknameRequest
+from domains.user.exceptions import DuplicateEmailException, PasswordMismatchException
 from domains.user.models import User
 
 
+# --- Fixtures ---
+@pytest.fixture
+def mock_user_repo():
+    return AsyncMock()
+
+
+@pytest.fixture
+def user_service(mock_user_repo):
+    return UserService(user_repo=mock_user_repo)
+
+
+@pytest.fixture
+def mock_user():
+    user = User(
+        email="test@example.com", password="hashed_password", nickname="tester", name="홍길동", birth="1990-01-01"
+    )
+    user.id = "user_id_123"
+    return user
+
+
+# --- Tests ---
 @pytest.mark.asyncio
-class TestUserService:
-    @pytest.fixture
-    def mock_repo(self):
-        """User Repository Mock"""
-        return AsyncMock()
+async def test_sign_up_success(user_service, mock_user_repo):
+    """[User Service] 회원가입 성공"""
+    # 중복 검사 통과 설정 (None 반환)
+    mock_user_repo.get_user_by_email.return_value = None
+    mock_user_repo.get_user_by_nickname.return_value = None
+    mock_user_repo.save_user.return_value = "saved_user_object"
 
-    @pytest.fixture
-    def mock_redis(self):
-        """Redis Client Mock"""
-        return AsyncMock()
+    request = SignUpRequest(
+        email="new@test.com",
+        password="password123!",
+        checked_password="password123!",
+        nickname="new_tester",
+        name="신규유저",
+        birth="2000-01-01",
+    )
 
-    @pytest.fixture
-    def service(self, mock_repo, mock_redis):
-        """UserService 인스턴스 (Mock 주입됨)"""
-        return UserService(mock_repo, mock_redis)
+    with patch("domains.user.service.security.hash_password", return_value="hashed_pwd"):
+        result = await user_service.sign_up(request)
+        assert result == "saved_user_object"
+        mock_user_repo.save_user.assert_called_once()
 
-    async def test_sign_up_success(self, service, mock_repo):
-        mock_repo.get_user_by_email.return_value = None
-        mock_repo.get_user_by_nickname.return_value = None
-        mock_repo.get_user_by_phone_num.return_value = None
 
-        request = SignUpRequest(
-            email="new@test.com",
-            password="password123",
-            checked_password="password123",
-            nickname="newuser",
-            name="신규",
-            phone_num="01012345678",
-        )
+@pytest.mark.asyncio
+async def test_sign_up_duplicate_email(user_service, mock_user_repo, mock_user):
+    """[User Service] 회원가입 실패 (이메일 중복)"""
+    mock_user_repo.get_user_by_email.return_value = mock_user  # 이미 유저 존재
 
-        mock_repo.save_user.side_effect = lambda u: u
+    request = SignUpRequest(
+        email="test@example.com",
+        password="password123!",
+        checked_password="password123!",
+        nickname="tester2",
+        name="홍길동",
+        birth="1990-01-01",
+    )
 
-        with patch("core.security.hash_password", return_value="hashed_pw"):
-            result = await service.sign_up(request)
+    with pytest.raises(DuplicateEmailException):
+        await user_service.sign_up(request)
 
-        assert result.email == "new@test.com"
-        mock_repo.save_user.assert_called_once()
 
-    async def test_sign_up_duplicate_email(self, service, mock_repo):
-        mock_repo.get_user_by_email.return_value = User(email="exist@test.com")
-        request = SignUpRequest(
-            email="exist@test.com",
-            password="password123",
-            checked_password="password123",
-            nickname="nick",
-        )
-        with pytest.raises(DuplicateEmailException):
-            await service.sign_up(request)
+@pytest.mark.asyncio
+async def test_find_email_success(user_service, mock_user_repo, mock_user):
+    """[User Service] 이메일 찾기 성공"""
+    mock_user_repo.find_user_by_recovery_info.return_value = mock_user
 
-    async def test_sign_up_password_mismatch(self, service, mock_repo):
-        mock_repo.get_user_by_email.return_value = None
-        mock_repo.get_user_by_nickname.return_value = None
-        request = SignUpRequest(
-            email="test@test.com",
-            password="password123",
-            checked_password="different123",  # 8자 이상
-            nickname="nick",
-        )
-        with pytest.raises(InvalidCheckedPasswordException):
-            await service.sign_up(request)
+    request = FindEmailRequest(name="홍길동", birth="1990-01-01", phone_num="01012345678")
 
-    async def test_log_in_success(self, service, mock_repo, mock_redis):
-        user_id = "user-uuid-123"
-        mock_user = User(id=user_id, email="login@test.com", password="hashed_pw")
-        mock_repo.get_user_by_email.return_value = mock_user
-        request = LogInRequest(email="login@test.com", password="real_password")
+    with patch("domains.user.service.security.make_phone_hash", return_value="hashed_phone"):
+        response = await user_service.find_email(request)
+        assert response.email == mock_user.email
 
-        with (
-            patch("core.security.verify_password", return_value=True),
-            patch("core.security.create_jwt", return_value="fake_access_token"),
-            patch("core.security.create_refresh_token", return_value="fake_refresh_token"),
-        ):
-            response = await service.log_in(request, req=None)
 
-        assert response.access_token == "fake_access_token"
-        assert response.refresh_token == "fake_refresh_token"
-        mock_redis.set.assert_called_once()
-        call_args = mock_redis.set.call_args[1]
-        assert call_args["name"] == "RT:fake_refresh_token"
-        assert call_args["value"] == user_id
+@pytest.mark.asyncio
+async def test_change_password_mismatch(user_service, mock_user_repo, mock_user):
+    """[User Service] 비밀번호 변경 실패 (새 비밀번호 확인 불일치)"""
+    mock_user_repo.get_user_by_id.return_value = mock_user
 
-    async def test_log_in_fail_wrong_password(self, service, mock_repo):
-        mock_user = User(email="login@test.com", password="hashed_pw")
-        mock_repo.get_user_by_email.return_value = mock_user
-        request = LogInRequest(email="login@test.com", password="wrong_pw_123")
+    request = ChangePasswordRequest(
+        current_password="old_password",
+        new_password="new_password_1",
+        checked_new_password="new_password_2",  # 불일치
+    )
 
-        with patch("core.security.verify_password", return_value=False):
-            with pytest.raises(InvalidCredentialsException):
-                await service.log_in(request, req=None)
+    with patch("domains.user.service.security.verify_password", side_effect=[True, False]):
+        # side_effect: 첫 번째 호출(기존비번검증)은 True, 두 번째 호출(새비번중복검증)은 False 반환
+        with pytest.raises(PasswordMismatchException):
+            await user_service.change_password(request, user_id="user_id_123")
 
-    async def test_refresh_token_success(self, service, mock_redis):
-        user_id = "user-uuid-123"
-        mock_redis.get.return_value = user_id
-        request = RefreshTokenRequest(refresh_token="valid_refresh_token")
 
-        with patch("core.security.create_jwt", return_value="new_access_token"):
-            response = await service.refresh_token(request)
+@pytest.mark.asyncio
+async def test_change_nickname_success(user_service, mock_user_repo, mock_user):
+    """[User Service] 닉네임 변경 성공"""
+    mock_user_repo.get_user_by_id.return_value = mock_user
+    mock_user_repo.get_user_by_nickname.return_value = None  # 변경하려는 닉네임이 중복되지 않음
 
-        mock_redis.get.assert_called_once_with("RT:valid_refresh_token")
-        assert response.access_token == "new_access_token"
+    request = ChangeNicknameRequest(nickname="brand_new_nick")
 
-    async def test_refresh_token_expired(self, service, mock_redis):
-        mock_redis.get.return_value = None
-        request = RefreshTokenRequest(refresh_token="expired_token")
+    await user_service.change_nickname(request, user_id="user_id_123")
 
-        with pytest.raises(TokenExpiredException):
-            await service.refresh_token(request)
-
-    async def test_log_out_success(self, service, mock_redis):
-        user_id = "user-uuid-123"
-        mock_redis.get.return_value = user_id
-        mock_redis.delete.return_value = 1
-        request = LogOutRequest(refresh_token="valid_token")
-
-        await service.log_out(request, user_id)
-
-        mock_redis.get.assert_called_once_with("RT:valid_token")
-        mock_redis.delete.assert_called_once_with("RT:valid_token")
-
-    async def test_log_out_fail_invalid_token(self, service, mock_redis):
-        mock_redis.get.return_value = None
-        request = LogOutRequest(refresh_token="missing_token")
-
-        with pytest.raises(TokenExpiredException):
-            await service.log_out(request, "any_user_id")
-
-    async def test_log_out_fail_forbidden(self, service, mock_redis):
-        mock_redis.get.return_value = "other_user"
-        request = LogOutRequest(refresh_token="others_token")
-
-        with pytest.raises(TokenForbiddenException):
-            await service.log_out(request, "my_user")
-
-    async def test_find_email_success(self, service, mock_repo):
-        mock_user = User(email="find@test.com")
-        mock_repo.find_user_by_recovery_info.return_value = mock_user
-
-        request = FindEmailRequest(name="김찾기", birth=date(1999, 1, 1), phone_num="01012345678")
-
-        with patch("core.security.make_phone_hash", return_value="hashed_phone"):
-            response = await service.find_email(request)
-
-        assert response.email == "find@test.com"
-
-    async def test_find_email_not_found(self, service, mock_repo):
-        mock_repo.find_user_by_recovery_info.return_value = None
-
-        request = FindEmailRequest(name="없음", birth=date(1999, 1, 1), phone_num="01012345678")
-
-        with patch("core.security.make_phone_hash", return_value="hashed_phone"):
-            with pytest.raises(UserNotFoundException):
-                await service.find_email(request)
-
-    # --- [비밀번호 변경 테스트 (수정됨: 8자 이상)] ---
-
-    async def test_change_password_success(self, service, mock_repo):
-        """[Service] 비밀번호 변경 성공"""
-        user_id = "uid"
-        mock_user = User(id=user_id, password="hashed_old_pw")
-        mock_repo.get_user_by_id.return_value = mock_user
-
-        request = ChangePasswordRequest(
-            current_password="old_password",  # 8자 이상
-            new_password="new_password",  # 8자 이상
-            checked_new_password="new_password",  # 8자 이상
-        )
-
-        with (
-            patch("core.security.verify_password") as mock_verify,
-            patch("core.security.hash_password", return_value="hashed_new_pw"),
-        ):
-            mock_verify.side_effect = [True, False]
-            await service.change_password(request, user_id)
-            mock_repo.update_user.assert_called_once()
-            assert mock_user.password == "hashed_new_pw"
-
-    async def test_change_password_fail_wrong_current(self, service, mock_repo):
-        """[Service] 현재 비밀번호 틀림 -> 예외"""
-        mock_user = User(password="hashed_old")
-        mock_repo.get_user_by_id.return_value = mock_user
-
-        request = ChangePasswordRequest(
-            current_password="wrong_password",  # 8자 이상
-            new_password="new_password",  # 8자 이상
-            checked_new_password="new_password",
-        )
-
-        with patch("core.security.verify_password", return_value=False):
-            with pytest.raises(IncorrectPasswordException):
-                await service.change_password(request, "uid")
-
-    async def test_change_password_fail_same_as_old(self, service, mock_repo):
-        """[Service] 새 비밀번호가 기존과 동일 -> 예외"""
-        mock_user = User(password="hashed_old")
-        mock_repo.get_user_by_id.return_value = mock_user
-
-        request = ChangePasswordRequest(
-            current_password="old_password",  # 8자 이상
-            new_password="old_password",  # 8자 이상
-            checked_new_password="old_password",
-        )
-
-        with patch("core.security.verify_password", return_value=True):
-            with pytest.raises(PasswordUnchangedException):
-                await service.change_password(request, "uid")
-
-    # --- [비밀번호 재설정 테스트 (수정됨: 8자 이상)] ---
-
-    async def test_reset_password_success(self, service, mock_repo):
-        """[Service] 비밀번호 재설정 성공"""
-        mock_user = User(
-            email="reset@test.com",
-            name="홍길동",
-            birth=date(2000, 1, 1),
-            phone_hash="hashed_phone",
-            password="old_hashed_pw",
-        )
-        mock_repo.get_user_by_email.return_value = mock_user
-
-        request = ResetPasswordRequest(
-            email="reset@test.com",
-            name="홍길동",
-            birth=date(2000, 1, 1),
-            phone_num="01012345678",
-            new_password="new_password",  # 8자 이상
-            checked_new_password="new_password",
-        )
-
-        with (
-            patch("core.security.make_phone_hash", return_value="hashed_phone"),
-            patch("core.security.verify_password", return_value=False),
-            patch("core.security.hash_password", return_value="new_hashed_pw"),
-        ):
-            await service.reset_password(request)
-            mock_repo.update_user.assert_called_once()
-            assert mock_user.password == "new_hashed_pw"
-
-    async def test_reset_password_fail_info_mismatch(self, service, mock_repo):
-        """[Service] 입력 정보 불일치 -> 예외"""
-        mock_user = User(email="test@test.com", name="김철수", phone_hash="hash")
-        mock_repo.get_user_by_email.return_value = mock_user
-
-        request = ResetPasswordRequest(
-            email="test@test.com",
-            name="홍길동",
-            birth=date(2000, 1, 1),
-            phone_num="01012345678",
-            new_password="new_password",  # 8자 이상
-            checked_new_password="new_password",
-        )
-
-        with patch("core.security.make_phone_hash", return_value="hash"):
-            with pytest.raises(UserNotFoundException):
-                await service.reset_password(request)
-
-    async def test_change_nickname_success(self, service, mock_repo):
-        user_id = "uid"
-        mock_user = User(id=user_id, nickname="old_nick")
-        mock_repo.get_user_by_id.return_value = mock_user
-        mock_repo.get_user_by_nickname.return_value = None
-
-        request = ChangeNicknameRequest(nickname="new_nick")
-
-        await service.change_nickname(request, user_id)
-
-        mock_repo.update_user.assert_called_once()
-        assert mock_user.nickname == "new_nick"
-
-    async def test_change_nickname_fail_same(self, service, mock_repo):
-        mock_user = User(id="uid", nickname="same_nick")
-        mock_repo.get_user_by_id.return_value = mock_user
-
-        request = ChangeNicknameRequest(nickname="same_nick")
-
-        with pytest.raises(DuplicateNicknameException) as exc:
-            await service.change_nickname(request, "uid")
-        assert exc.value.detail == "현재 닉네임과 동일합니다."
-
-    async def test_change_nickname_fail_duplicate(self, service, mock_repo):
-        mock_user = User(id="uid", nickname="old_nick")
-        mock_repo.get_user_by_id.return_value = mock_user
-        mock_repo.get_user_by_nickname.return_value = User(nickname="taken_nick")
-
-        request = ChangeNicknameRequest(nickname="taken_nick")
-
-        with pytest.raises(DuplicateNicknameException) as exc:
-            await service.change_nickname(request, "uid")
-        assert exc.value.detail == "이미 사용 중인 닉네임입니다."
+    assert mock_user.nickname == "brand_new_nick"
+    mock_user_repo.update_user.assert_called_once_with(mock_user)


### PR DESCRIPTION
- user의 코드가 너무 길어서 auth와 user를 분리함
- 테스트 코드 분리
- 기존에 있던 에러 관련 리팩토링 예정
# 관련 이슈
Closes #51 